### PR TITLE
Bump Candybar & Gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,7 +60,7 @@ android {
 dependencies {
 
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'com.github.donnnno:candybar-foss:3.20.2'
+    implementation 'com.github.donnnno:candybar-foss:3.20.4'
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.5.1'
+        classpath 'com.android.tools.build:gradle:8.7.3'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ allprojects {
     rootProject.ext {
         MinSdk = 21
         TargetSdk = 34
-        CompileSdk = 34
+        CompileSdk = 35
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip


### PR DESCRIPTION
While trying to build `snow` from source, I had trouble getting PhotoView/1.3.1 from JitPack (https://github.com/jitpack/jitpack.io/issues/6727), that is required by Candybar FOSS 3.20.2. This dependency is gone with Candybar FOSS 3.20.4, but it also required to upgrade `CompileSdk` to 35.